### PR TITLE
[TextReplacer] Fix settings saving and implement loading of the settings on plugin startup

### DIFF
--- a/TextReplacer/TextReplacer.plugin.js
+++ b/TextReplacer/TextReplacer.plugin.js
@@ -30,7 +30,7 @@ module.exports = meta => ({
     start() {
         // Load the saved settings
         let loadedSettings = BD.Data.load("settings");
-        if (typeof loadedSettings === 'object' && loadedSettings !== null) {
+        if (typeof loadedSettings === 'object' && loadedSettings !== null && !(loadedSettings instanceof Array)) {
             Object.assign(settings, loadedSettings);
         }
 

--- a/TextReplacer/TextReplacer.plugin.js
+++ b/TextReplacer/TextReplacer.plugin.js
@@ -30,7 +30,7 @@ module.exports = meta => ({
     start() {
         // Load the saved settings
         let loadedSettings = BD.Data.load("settings");
-        if (loadedSettings != undefined) {
+        if (typeof loadedSettings === 'object' && loadedSettings !== null) {
             Object.assign(settings, loadedSettings);
         }
 

--- a/TextReplacer/TextReplacer.plugin.js
+++ b/TextReplacer/TextReplacer.plugin.js
@@ -28,6 +28,12 @@ function updateSettings(newSettings) {
 
 module.exports = meta => ({
     start() {
+        // Load the saved settings
+        let loadedSettings = BD.Data.load("settings");
+        if (loadedSettings != undefined) {
+            Object.assign(settings, loadedSettings);
+        }
+
         BD.Patcher.before(MessageActions, "sendMessage", (_, args) => {
             const msg = args[1];
             let definedRegex;

--- a/TextReplacer/TextReplacer.plugin.js
+++ b/TextReplacer/TextReplacer.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name TextReplacer
  * @author MahdeenSky
- * @version 1.1
+ * @version 1.2
  * @description Can replace text in messages using regex before sending them. By default, it fixes twitter and pixiv links.
  * @source https://github.com/MahdeenSky/BDPlugins/blob/main/TextReplacer/TextReplacer.plugin.js
  */

--- a/TextReplacer/TextReplacer.plugin.js
+++ b/TextReplacer/TextReplacer.plugin.js
@@ -23,7 +23,7 @@ const settings = {
 // Function to update and save settings
 function updateSettings(newSettings) {
     Object.assign(settings, newSettings);
-    BD.Data.save("TextReplacer", "settings", settings);
+    BD.Data.save("settings", settings);
 }
 
 module.exports = meta => ({


### PR DESCRIPTION
This pull request fixes a bug that was causing the settings to not be saved properly (instead of the config json containing the settings object under "settings", the string "settings" was being saved under the plugin's name).
In addition to that, settings weren't being loaded from the file on startup. This is also fixed in this pull request.